### PR TITLE
Fix clang-format trailing comment spacing

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -86,7 +86,7 @@ SpaceAfterTemplateKeyword: false
 SpaceBeforeAssignmentOperators: true
 SpaceBeforeParens: ControlStatements
 SpaceInEmptyParentheses: false
-SpacesBeforeTrailingComments: 0
+SpacesBeforeTrailingComments: 1
 SpacesInAngles: false
 SpacesInCStyleCastParentheses: false
 SpacesInContainerLiterals: true

--- a/benchmark/benchmark.cpp
+++ b/benchmark/benchmark.cpp
@@ -68,7 +68,7 @@ template<typename Count, typename Duration> auto events_per_second(Count event_c
   return static_cast<long long>(static_cast<double>(event_count) / seconds);
 }
 
-}// namespace
+} // namespace
 
 // NOLINTNEXTLINE(bugprone-exception-escape) - std::println may throw but we accept that in benchmarks
 int main()

--- a/benchmark/benchmark_threaded.cpp
+++ b/benchmark/benchmark_threaded.cpp
@@ -16,7 +16,7 @@ template<typename Count, typename Duration> auto events_per_second(Count event_c
   return static_cast<long long>(static_cast<double>(event_count) / seconds);
 }
 
-}// namespace
+} // namespace
 
 // =============================================================================
 // Define event types
@@ -151,7 +151,7 @@ struct D_OwnThread_Starter
 namespace {
 constexpr int kOwnThreadTargetCount = 10'000'000;
 constexpr int kMixedTargetCount = 1'000'000;
-}// namespace
+} // namespace
 
 void benchmark_ownthread_to_ownthread()
 {

--- a/example/main.cpp
+++ b/example/main.cpp
@@ -134,7 +134,7 @@ struct ChainHandler
 namespace {
 constexpr int kMaxPollIterations = 100;
 constexpr int kThreadedReceiverDelayMs = 50;
-}// namespace
+} // namespace
 
 // NOLINTNEXTLINE(bugprone-exception-escape) - std::println may throw but we accept that in examples
 int main()

--- a/include/ev_loop/ev.hpp
+++ b/include/ev_loop/ev.hpp
@@ -131,8 +131,8 @@ public:
   {
     if (tag != uninitialized_tag) {
       move_construct_from(std::move(other));
-      other.destroy();// cppcheck-suppress accessMoved ; other.destroy() only resets tag, the moved-from object is in
-                      // valid state
+      other.destroy(); // cppcheck-suppress accessMoved ; other.destroy() only resets tag, the moved-from object is in
+                       // valid state
     }
   }
 
@@ -155,8 +155,8 @@ public:
       tag = other.tag;
       if (tag != uninitialized_tag) {
         move_construct_from(std::move(other));
-        other.destroy();// cppcheck-suppress accessMoved ; other.destroy() only resets tag, the moved-from object is in
-                        // valid state
+        other.destroy(); // cppcheck-suppress accessMoved ; other.destroy() only resets tag, the moved-from object is in
+                         // valid state
       }
     }
     return *this;
@@ -324,8 +324,8 @@ private:
 // =============================================================================
 
 enum class ThreadMode : std::uint8_t {
-  SameThread,// Runs on event loop thread, uses queue dispatch
-  OwnThread// Runs on its own thread, direct push from emitters
+  SameThread, // Runs on event loop thread, uses queue dispatch
+  OwnThread // Runs on its own thread, direct push from emitters
 };
 
 // =============================================================================
@@ -691,12 +691,12 @@ private:
     has_remote_.store(false, std::memory_order_release);
   }
 
-  RingBuffer<TaggedEventType> local_queue_;// Same-thread access only
-  std::queue<TaggedEventType> remote_queue_;// Cross-thread, protected by mutex
+  RingBuffer<TaggedEventType> local_queue_; // Same-thread access only
+  std::queue<TaggedEventType> remote_queue_; // Cross-thread, protected by mutex
   std::mutex mutex_;
   std::condition_variable cv_;
   std::atomic<bool> has_remote_{ false };
-  std::atomic<bool> waiting_{ false };// True when consumer is blocked on CV
+  std::atomic<bool> waiting_{ false }; // True when consumer is blocked on CV
   bool stop_ = false;
 };
 
@@ -808,7 +808,7 @@ public:
     tagged_event tagged;
     tagged.store(std::forward<Event>(event));
     queue_.push(std::move(tagged));
-    queue_.notify();// Wake up consumer
+    queue_.notify(); // Wake up consumer
   }
 
   [[nodiscard]] Receiver& get() & noexcept { return receiver_; }
@@ -1069,7 +1069,7 @@ template<typename EventLoop> struct Hybrid
     auto* event = event_loop.try_get_event();
     if (event != nullptr) {
       event_loop.dispatch_event(*event);
-      empty_spins = 0;// Reset counter on successful dispatch
+      empty_spins = 0; // Reset counter on successful dispatch
       return true;
     }
 
@@ -1412,4 +1412,4 @@ template<typename... Receivers> struct ValidateReceivers
     return (ReceiverValidator<Receivers, EventLoopType>::validate() && ...);
   }
 };
-}// namespace ev_loop
+} // namespace ev_loop

--- a/test/constexpr_tests.cpp
+++ b/test/constexpr_tests.cpp
@@ -53,7 +53,7 @@ TEST_CASE("tag_type_t selects smallest sufficient type", "[constexpr]")
   // uint32_t range: 65535 to uint32_max-1
   STATIC_REQUIRE(sizeof(ev_loop::tag_type_t<65535>) == 4);
   STATIC_REQUIRE(sizeof(ev_loop::tag_type_t<100000>) == 4);
-  STATIC_REQUIRE(sizeof(ev_loop::tag_type_t<4294967294UL>) == 4);// max valid value
+  STATIC_REQUIRE(sizeof(ev_loop::tag_type_t<4294967294UL>) == 4); // max valid value
 
   // Values >= uint32_max trigger static_assert: "Too many event types (max ~4 billion)"
 }

--- a/test/test_builder.cpp
+++ b/test/test_builder.cpp
@@ -29,7 +29,7 @@ struct BuilderReceiverB
 
 namespace {
 constexpr int kTestValue = 42;
-}// namespace
+} // namespace
 
 TEST_CASE("Builder", "[builder]")
 {

--- a/test/test_builder_duplicate_fail.cpp
+++ b/test/test_builder_duplicate_fail.cpp
@@ -22,7 +22,7 @@ int main()
   // "Receiver type is already registered in this Builder"
   auto loop = ev_loop::Builder{}
                 .add<MyReceiver>()
-                .add<MyReceiver>()// Duplicate - should trigger static_assert
+                .add<MyReceiver>() // Duplicate - should trigger static_assert
                 .build();
 
   (void)loop;

--- a/test/test_event_loop.cpp
+++ b/test/test_event_loop.cpp
@@ -11,7 +11,7 @@ constexpr int kPingPongExpectedCount = 6;
 constexpr int kPingPongLastValue = 11;
 constexpr std::size_t kLongStringSize = 1000;
 constexpr std::size_t kHybridSpinCount = 10;
-}// namespace
+} // namespace
 
 // =============================================================================
 // Event types

--- a/test/test_move_optimization.cpp
+++ b/test/test_move_optimization.cpp
@@ -9,7 +9,7 @@
 
 namespace {
 constexpr int kPollDelayMs = 1;
-}// namespace
+} // namespace
 
 // =============================================================================
 // Same thread receivers

--- a/test/test_queue.cpp
+++ b/test/test_queue.cpp
@@ -12,7 +12,7 @@ constexpr std::size_t kMediumQueueCapacity = 8;
 constexpr std::size_t kLargeQueueCapacity = 16;
 constexpr int kWraparoundRounds = 10;
 constexpr int kMemoryTestIterations = 100;
-}// namespace
+} // namespace
 
 // =============================================================================
 // RingBuffer Tests

--- a/test/test_tagged_event.cpp
+++ b/test/test_tagged_event.cpp
@@ -312,8 +312,8 @@ TEST_CASE("tag_type_selector", "[tagged_event]")
     REQUIRE(small_tagged.index() == kUninitializedTag);
 
     // Verify the tag type sizes are what we expect
-    REQUIRE(sizeof(ev_loop::tag_type_t<kTagTypeCount100>) == kTagTypeSizeSmall);// uint8_t
-    REQUIRE(sizeof(ev_loop::tag_type_t<kTagTypeCount255>) == kTagTypeSizeMedium);// uint16_t
-    REQUIRE(sizeof(ev_loop::tag_type_t<kTagTypeCount65535>) == kTagTypeSizeLarge);// uint32_t
+    REQUIRE(sizeof(ev_loop::tag_type_t<kTagTypeCount100>) == kTagTypeSizeSmall); // uint8_t
+    REQUIRE(sizeof(ev_loop::tag_type_t<kTagTypeCount255>) == kTagTypeSizeMedium); // uint16_t
+    REQUIRE(sizeof(ev_loop::tag_type_t<kTagTypeCount65535>) == kTagTypeSizeLarge); // uint32_t
   }
 }

--- a/test/test_threaded.cpp
+++ b/test/test_threaded.cpp
@@ -23,7 +23,7 @@ constexpr int kPollDelayMs = 1;
 constexpr int kSettleDelayMs = 10;
 constexpr int kSpinDelayUs = 100;
 constexpr std::size_t kHybridSpinCount = 100;
-}// namespace
+} // namespace
 
 // =============================================================================
 // Event types


### PR DESCRIPTION
Set SpacesBeforeTrailingComments to 1 and reformat all source files.