### PR TITLE
Enable Setup::create() to return by value

### DIFF
--- a/include/ev_loop/ev.hpp
+++ b/include/ev_loop/ev.hpp
@@ -1284,52 +1284,44 @@ public:
         std::move(events_), std::make_tuple(std::forward<Event>(event))) };
     }
 
-    // Create EventLoop on stack (relies on NRVO)
+    // Create EventLoop on stack - returns prvalue for guaranteed copy elision
     [[nodiscard]] auto create() const& -> GroupEventLoop
     {
-      GroupEventLoop loop{ typename GroupEventLoop::ConstructToken{} };
-      std::apply([&loop](const auto&... events) { (loop.prime_event(events), ...); }, events_);
-      return loop;
+      return std::apply(
+        [](const auto&... events) { return GroupEventLoop{ typename GroupEventLoop::ConstructToken{}, events... }; },
+        events_);
     }
 
     // Create EventLoop on stack (moves events - rvalue overload)
     [[nodiscard]] auto create() && -> GroupEventLoop
     {
-      GroupEventLoop loop{ typename GroupEventLoop::ConstructToken{} };
-      std::apply([&loop](auto&&... events) { (loop.prime_event(std::forward<decltype(events)>(events)), ...); },
+      return std::apply(
+        [](auto&&... events) {
+          return GroupEventLoop{ typename GroupEventLoop::ConstructToken{}, std::forward<decltype(events)>(events)... };
+        },
         std::move(events_));
-      return loop;
-    }
-
-    // Create with factory (e.g., std::make_unique<Loop>)
-    template<typename Factory> [[nodiscard]] auto create(Factory&& factory) const&
-    {
-      auto loop = std::invoke(std::forward<Factory>(factory));
-      std::apply([&loop](const auto&... events) { (loop->prime_event(events), ...); }, events_);
-      return loop;
-    }
-
-    // Create with factory (moves events - rvalue overload)
-    template<typename Factory> [[nodiscard]] auto create(Factory&& factory) &&
-    {
-      auto loop = std::invoke(std::forward<Factory>(factory));
-      std::apply([&loop](auto&&... events) { (loop->prime_event(std::forward<decltype(events)>(events)), ...); },
-        std::move(events_));
-      return loop;
     }
 
     // Create on heap (returns unique_ptr)
     [[nodiscard]] auto create_unique() && -> std::unique_ptr<GroupEventLoop>
     {
-      return std::move(*this).create(
-        [] { return std::make_unique<GroupEventLoop>(typename GroupEventLoop::ConstructToken{}); });
+      return std::apply(
+        [](auto&&... events) {
+          return std::make_unique<GroupEventLoop>(
+            typename GroupEventLoop::ConstructToken{}, std::forward<decltype(events)>(events)...);
+        },
+        std::move(events_));
     }
 
     // Create on heap (returns shared_ptr)
     [[nodiscard]] auto create_shared() && -> std::shared_ptr<GroupEventLoop>
     {
-      return std::move(*this).create(
-        [] { return std::make_shared<GroupEventLoop>(typename GroupEventLoop::ConstructToken{}); });
+      return std::apply(
+        [](auto&&... events) {
+          return std::make_shared<GroupEventLoop>(
+            typename GroupEventLoop::ConstructToken{}, std::forward<decltype(events)>(events)...);
+        },
+        std::move(events_));
     }
   };
 
@@ -1359,6 +1351,12 @@ private:
 public:
   // Public constructor guarded by private token - enables std::make_unique/make_shared
   explicit GroupEventLoop(ConstructToken /*unused*/) {}
+
+  // Constructor that primes events - enables guaranteed copy elision from Setup::create()
+  template<typename... Events> explicit GroupEventLoop(ConstructToken /*unused*/, Events&&... events)
+  {
+    (prime_event(std::forward<Events>(events)), ...);
+  }
 
   // Start all groups on their own threads (returns immediately)
   void start() { start_threads(); }

--- a/include/ev_loop/ev.hpp
+++ b/include/ev_loop/ev.hpp
@@ -1285,19 +1285,24 @@ public:
     }
 
     // Create EventLoop on stack - returns prvalue for guaranteed copy elision
-    [[nodiscard]] auto create() const& -> GroupEventLoop
-    {
-      return std::apply(
-        [](const auto&... events) { return GroupEventLoop{ typename GroupEventLoop::ConstructToken{}, events... }; },
-        events_);
-    }
-
-    // Create EventLoop on stack (moves events - rvalue overload)
-    [[nodiscard]] auto create() && -> GroupEventLoop
+    template<typename Self> [[nodiscard]] auto create(this Self&& self) -> GroupEventLoop
     {
       return std::apply(
         [](auto&&... events) {
           return GroupEventLoop{ typename GroupEventLoop::ConstructToken{}, std::forward<decltype(events)>(events)... };
+        },
+        std::forward<Self>(self).events_);
+    }
+
+    // Create with custom factory (e.g., custom allocator)
+    // Factory signature: (ConstructToken, Events...) -> PointerType
+    template<typename Factory> [[nodiscard]] auto create(Factory&& factory) &&
+    {
+      return std::apply(
+        [&factory](auto&&... events) {
+          return std::invoke(std::forward<Factory>(factory),
+            typename GroupEventLoop::ConstructToken{},
+            std::forward<decltype(events)>(events)...);
         },
         std::move(events_));
     }
@@ -1305,23 +1310,19 @@ public:
     // Create on heap (returns unique_ptr)
     [[nodiscard]] auto create_unique() && -> std::unique_ptr<GroupEventLoop>
     {
-      return std::apply(
-        [](auto&&... events) {
-          return std::make_unique<GroupEventLoop>(
-            typename GroupEventLoop::ConstructToken{}, std::forward<decltype(events)>(events)...);
-        },
-        std::move(events_));
+      return std::move(*this).create([](auto&& token, auto&&... events) {
+        return std::make_unique<GroupEventLoop>(
+          std::forward<decltype(token)>(token), std::forward<decltype(events)>(events)...);
+      });
     }
 
     // Create on heap (returns shared_ptr)
     [[nodiscard]] auto create_shared() && -> std::shared_ptr<GroupEventLoop>
     {
-      return std::apply(
-        [](auto&&... events) {
-          return std::make_shared<GroupEventLoop>(
-            typename GroupEventLoop::ConstructToken{}, std::forward<decltype(events)>(events)...);
-        },
-        std::move(events_));
+      return std::move(*this).create([](auto&& token, auto&&... events) {
+        return std::make_shared<GroupEventLoop>(
+          std::forward<decltype(token)>(token), std::forward<decltype(events)>(events)...);
+      });
     }
   };
 

--- a/test/test_setup.cpp
+++ b/test/test_setup.cpp
@@ -2,6 +2,7 @@
 #include <atomic>
 #include <catch2/catch_test_macros.hpp>
 #include <ev_loop/ev.hpp>
+#include <memory>
 #include <utility>
 // NOLINTEND(misc-include-cleaner)
 
@@ -112,6 +113,17 @@ TEST_CASE("Setup builder", "[setup]")
     // No events primed, so poll returns false immediately
     REQUIRE_FALSE(loop->poll_group<0>());
     REQUIRE(loop->get<ReceiverA>().count.load() == 0);
+  }
+
+  SECTION("create(Factory) with custom factory")
+  {
+    auto loop = Loop::setup().prime(EventA{ .value = kTestValue1 }).create([](auto&& token, auto&&... events) {
+      return std::make_unique<Loop>(std::forward<decltype(token)>(token), std::forward<decltype(events)>(events)...);
+    });
+
+    while (loop->poll_group<0>()) {}
+
+    REQUIRE(loop->get<ReceiverA>().count.load() == kTestValue1);
   }
 }
 // NOLINTEND(readability-function-cognitive-complexity)

--- a/test/test_setup.cpp
+++ b/test/test_setup.cpp
@@ -67,5 +67,51 @@ TEST_CASE("Setup builder", "[setup]")
 
     REQUIRE(loop->get<ReceiverA>().count.load() == kTestValue1);
   }
+
+  SECTION("create() returns by value without primed events")
+  {
+    auto loop = Loop::setup().create();
+
+    // No events primed, so poll returns false immediately
+    REQUIRE_FALSE(loop.poll_group<0>());
+    REQUIRE(loop.get<ReceiverA>().count.load() == 0);
+  }
+
+  SECTION("create() returns by value with primed events")
+  {
+    auto loop = Loop::setup().prime(EventA{ .value = kTestValue1 }).create();
+
+    while (loop.poll_group<0>()) {}
+
+    REQUIRE(loop.get<ReceiverA>().count.load() == kTestValue1);
+  }
+
+  SECTION("create() with multiple primed events")
+  {
+    auto loop =
+      Loop::setup().prime(EventA{ .value = 1 }).prime(EventA{ .value = 2 }).prime(EventA{ .value = 3 }).create();
+
+    while (loop.poll_group<0>()) {}
+
+    REQUIRE(loop.get<ReceiverA>().count.load() == 6);
+  }
+
+  SECTION("create_shared() returns shared_ptr")
+  {
+    auto loop = Loop::setup().prime(EventA{ .value = kTestValue1 }).create_shared();
+
+    while (loop->poll_group<0>()) {}
+
+    REQUIRE(loop->get<ReceiverA>().count.load() == kTestValue1);
+  }
+
+  SECTION("create_shared() without primed events")
+  {
+    auto loop = Loop::setup().create_shared();
+
+    // No events primed, so poll returns false immediately
+    REQUIRE_FALSE(loop->poll_group<0>());
+    REQUIRE(loop->get<ReceiverA>().count.load() == 0);
+  }
 }
 // NOLINTEND(readability-function-cognitive-complexity)


### PR DESCRIPTION
## Summary

Enable `Setup::create()` to return `GroupEventLoop` by value using guaranteed copy elision, even though `GroupEventLoop` is non-movable (due to `std::atomic` members).

## Changes

- Add `GroupEventLoop(ConstructToken, Events&&...)` constructor that primes events during construction
- Update `Setup::create()` to use `std::apply` with a lambda that returns a prvalue
- Simplify `create_unique()` and `create_shared()` to use the new constructor
- Remove intermediate factory overloads (no longer needed)

## Usage

```cpp
// Now works - returns by value via guaranteed copy elision
auto loop = Loop::setup().prime(X).prime(Y).create();
loop.start();
loop.stop();
```

## How it works

Instead of:
```cpp
GroupEventLoop loop{token};
(loop.prime_event(events), ...);
return loop;  // ERROR: tries to move non-movable type
```

We now do:
```cpp
return std::apply([](auto&&... events) {
  return GroupEventLoop{token, std::forward<decltype(events)>(events)...};
}, events_);  // Returns prvalue - guaranteed copy elision
```

## Test plan

- [x] All existing tests pass
- [x] README examples compile with `create()`