### PR TITLE
Fix compiler version requirements in docs

### DIFF
--- a/README_dependencies.md
+++ b/README_dependencies.md
@@ -34,13 +34,13 @@ See [cppreference.com](https://en.cppreference.com/w/cpp/compiler_support)
 to see which features are supported by each compiler.
 The following compilers should work:
 
-  * [GCC 13+](https://gcc.gnu.org/)
+  * [GCC 14+](https://gcc.gnu.org/)
 	<details>
 	<summary>Install command</summary>
 
 	- Debian/Ubuntu:
 
-			sudo apt install g++-13
+			sudo apt install g++-14
 
 	- Windows:
 
@@ -48,10 +48,10 @@ The following compilers should work:
 
 	- MacOS:
 
-			brew install gcc@13
+			brew install gcc@14
 	</details>
 
-  * [Clang 17+](https://clang.llvm.org/)
+  * [Clang 18+](https://clang.llvm.org/)
 	<details>
 	<summary>Install command</summary>
 
@@ -68,7 +68,7 @@ The following compilers should work:
 		llvm-utils for using external LLVM with Visual Studio generator:
 
 			git clone https://github.com/zufuliu/llvm-utils.git
-			cd llvm-utils/VS2017
+			cd llvm-utils/VS2022
 			.\install.bat
 
 	- MacOS:

--- a/README_docker.md
+++ b/README_docker.md
@@ -15,7 +15,7 @@ If you want to build this container using specific versions of gcc and clang,
 you may do so with the `GCC_VER` and `LLVM_VER` arguments:
 
 ```bash
-docker build --tag=ev_loop:latest --build-arg GCC_VER=13 --build-arg LLVM_VER=17 .
+docker build --tag=ev_loop:latest --build-arg GCC_VER=14 --build-arg LLVM_VER=18 .
 ```
 
 To use clang as your default CC and CXX environment variables:


### PR DESCRIPTION
## Summary
- GCC 13+ → GCC 14+ (required for C++23 "deducing this")
- Clang 17+ → Clang 18+ (required for C++23 "deducing this")
- Update Docker example to use GCC 14/LLVM 18
- Fix VS2017 → VS2022 in llvm-utils instructions

## Test plan
- [x] Verified with Docker build that GCC 14 and Clang 18 are required