### PR TITLE
Fix CPack to include headers in package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,8 +117,8 @@ ev_loop_package_project(
   ev_loop
   ev_loop_options
   ev_loop_warnings
-  # FIXME: this does not work! CK
-  # PRIVATE_DEPENDENCIES_CONFIGURED project_options project_warnings
+  PUBLIC_INCLUDES
+  include
 )
 
 # Experience shows that explicit package naming can help make it easier to sort


### PR DESCRIPTION
## Summary
The CPack package was missing the header file because `PUBLIC_INCLUDES` was not specified in `ev_loop_package_project()`.

Added `PUBLIC_INCLUDES include` to include the `ev_loop/ev.hpp` header in the package.

## Test plan
- [x] Verified locally with `cpack -G TBZ2`
- [x] Package now contains `include/ev_loop/ev.hpp`

Fixes #37