### PR TITLE
Exclude TrackingCounter member initializers from coverage

### DIFF
--- a/test/test_utils.hpp
+++ b/test/test_utils.hpp
@@ -46,6 +46,7 @@ template<typename Derived> struct WaitableReceiver
 
 struct TrackingCounter
 {
+  // GCOVR_EXCL_START - Inline member initializers not tracked by coverage tools
   // cppcheck-suppress unusedStructMember
   std::atomic<int> constructed_count{ 0 };
   // cppcheck-suppress unusedStructMember
@@ -54,6 +55,7 @@ struct TrackingCounter
   std::atomic<int> move_count{ 0 };
   // cppcheck-suppress unusedStructMember
   std::atomic<int> copy_count{ 0 };
+  // GCOVR_EXCL_STOP
 
   [[nodiscard]] bool balanced() const { return constructed_count.load() == destructed_count.load(); }
 };


### PR DESCRIPTION
## Summary
Exclude `TrackingCounter` inline member initializers from coverage reporting.

Coverage tools (gcov/llvm-cov) don't properly track inline member initializers like `std::atomic<int> count{ 0 }`, causing false negatives in coverage reports.

## Test plan
- [x] Builds and tests pass
- [x] Coverage reports no longer show these lines as uncovered