### PR TITLE
ci: skip codecov upload on dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,6 +199,7 @@ jobs:
 
 
       - name: Publish to codecov
+        if: github.actor != 'dependabot[bot]'
         uses: codecov/codecov-action@v5
         with:
           fail_ci_if_error: true # we weren't posting previously


### PR DESCRIPTION
Dependabot-triggered workflow runs don't receive Actions secrets, so `${{ secrets.CODECOV_TOKEN }}` is empty (`Token length: 0`) and the upload fails with `Token required because branch is protected` — failing CI on every Dependabot PR (e.g. #45).

Guard the codecov step with `if: github.actor != 'dependabot[bot]'`. A dependency version bump doesn't change coverage, so skipping the upload there loses nothing; pushes and human PRs still upload as before. Avoids duplicating the token into the Dependabot secret store.