### PR TITLE
ci: install codecov CLI from PyPI to avoid GPG keyserver flake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,6 +203,7 @@ jobs:
         uses: codecov/codecov-action@v7
         with:
           fail_ci_if_error: true # we weren't posting previously
+          use_pypi: true # avoid flaky GPG keyserver verification
           flags: ${{ runner.os }}
           name: ${{ runner.os }}-coverage
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
The codecov uploader wrapper fetches codecov's public key from a keyserver to verify the CLI signature. That download intermittently returns empty (`gpg: no valid OpenPGP data found`), so verification fails with `Can't check signature: No public key` and the whole job exits 1.

`use_pypi: true` installs the CLI via pip from PyPI instead, which never touches the keyserver and verifies via package hashes. `fail_ci_if_error: true` stays on.